### PR TITLE
feat: update Go version to 1.21 and related dependencies

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -31,7 +31,7 @@ steps:
         - GOPATH
         - GOBIN
   - name: go-init
-    image: golang:1.19.13
+    image: golang:1.21.13
     pull: if-not-exists
     volumes:
       - name: go_cache
@@ -50,7 +50,7 @@ steps:
     depends_on: # https://docs.drone.io/pipeline/exec/syntax/parallelism/
       - go-init
 
-    image: golang:1.19.13
+    image: golang:1.21.13
     pull: if-not-exists
     volumes:
       - name: go_cache
@@ -68,7 +68,7 @@ steps:
     depends_on: # https://docs.drone.io/pipeline/exec/syntax/parallelism/
       - go-test
 
-    image: golang:1.19.13
+    image: golang:1.21.13
     pull: if-not-exists
     volumes:
       - name: go_cache

--- a/.github/workflows-template/go-release-template.md
+++ b/.github/workflows-template/go-release-template.md
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go SDK
         uses: actions/setup-go@v4
         with:
-          go-version: '^1.19'
+          go-version: '^1.21'
           cache: false
       - name: Build Release binary
         run: |

--- a/.github/workflows-template/golang-codecov.md
+++ b/.github/workflows-template/golang-codecov.md
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         go:
-          - '^1.19'
+          - '^1.21'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows-template/golang-codecov.yml
+++ b/.github/workflows-template/golang-codecov.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         go:
-          - '^1.19'
+          - '^1.21'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/go-release-platform.yml
+++ b/.github/workflows/go-release-platform.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Go SDK
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.19'
+          go-version: '^1.21'
           cache: false
 
       - name: Build Release binary

--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - '^1.19'
-          - '1.19.13'
+          - '^1.21'
+          - '1.21.13'
         os:
           - macos-latest
           - windows-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Author: bridgewwater
 # dockerfile offical document https://docs.docker.com/engine/reference/builder/
 # https://hub.docker.com/_/golang
-FROM golang:1.19.13 as builder
+FROM golang:1.21.13 as builder
 
 ARG GO_ENV_PACKAGE_NAME=github.com/bridgewwater/temp-golang-cli-fast
 ARG GO_ENV_ROOT_BUILD_BIN_NAME=temp-golang-cli-fast

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ROOT_NAME ?=temp-golang-cli-fast
 
 ## MakeDocker.mk settings start
 ROOT_OWNER ?=bridgewwater
-ROOT_PARENT_SWITCH_TAG =1.19.13
+ROOT_PARENT_SWITCH_TAG =1.21.13
 # for image local build
 INFO_TEST_BUILD_DOCKER_PARENT_IMAGE =golang
 # for image running

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ### cli tools to init project fast
 
 ```bash
-$ v=1.6.0; curl -L --fail https://raw.githubusercontent.com/bridgewwater/temp-golang-cli-fast/v$v/temp-golang-cli-fast -o temp-golang-cli-fast
+$ v=1.7.0; curl -L --fail https://raw.githubusercontent.com/bridgewwater/temp-golang-cli-fast/v$v/temp-golang-cli-fast -o temp-golang-cli-fast
 # let temp-golang-cli-fast file folder under $PATH
 $ chmod +x temp-golang-cli-fast
 # see how to use

--- a/build.dockerfile
+++ b/build.dockerfile
@@ -3,7 +3,7 @@
 # Author: bridgewwater
 # dockerfile offical document https://docs.docker.com/engine/reference/builder/
 # https://hub.docker.com/_/golang
-FROM golang:1.19.13 as builder
+FROM golang:1.21.13 as builder
 
 ARG GO_ENV_PACKAGE_NAME=github.com/bridgewwater/temp-golang-cli-fast
 ARG GO_ENV_ROOT_BUILD_BIN_NAME=temp-golang-cli-fast

--- a/doc-dev/dev.md
+++ b/doc-dev/dev.md
@@ -2,19 +2,30 @@
 
 ## env
 
-- minimum go version: go 1.19
-- change `go 1.19`, `^1.19`, `1.19.13` to new go version
-- change `golangci-lint@v1.53.3` from [golangci-lint version release](https://github.com/golangci/golangci-lint/releases) to new version
-  - more info see [golangci-lint local-installation](https://golangci-lint.run/usage/install/#local-installation)
+- minimum go version: go 1.21
+- change `go 1.21`, `^1.21`, `1.21.13` to new go version
+- change `golangci-lint@v1.59.1`
+  from [golangci-lint version release](https://github.com/golangci/golangci-lint/releases) to new version
+    - more info see [golangci-lint local-installation](https://golangci-lint.run/usage/install/#local-installation)
+
+```
+          # version: v1.61.0 for go verison 1.22.1+
+          # version: v1.59.1 for go verison 1.21+
+          # version: v1.55.2 for go verison 1.20+
+          # version: v1.53.3 for go verison 1.19+
+          # version: v1.45.2 for go verison 1.18+
+          # version: v1.42.1 for go verison 1.17+
+          # version: v1.41.0 for go verison 1.16+
+```
 
 ### libs
 
 | lib                                 | version |
 |:------------------------------------|:--------|
 | https://github.com/stretchr/testify | v1.9.0  |
-| https://github.com/sebdah/goldie    | v2.5.3  |
-| https://github.com/gookit/color     | v1.5.3  |
-| https://github.com/urfave/cli/      | v2.27.2 |
+| https://github.com/sebdah/goldie    | v2.5.5  |
+| https://github.com/gookit/color     | v1.5.4  |
+| https://github.com/urfave/cli/      | v2.27.4 |
 
 - more libs see [go.mod](https://github.com/bridgewwater/temp-golang-cli-fast/blob/main/go.mod)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/bridgewwater/temp-golang-cli-fast
 
-go 1.19
+go 1.21
+
+toolchain go1.21.13
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.0

--- a/temp-golang-cli-fast
+++ b/temp-golang-cli-fast
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 # and this use tag
-temple_version='1.6.0'
+temple_version='1.7.0'
 new_version_for_dev='1.0.0'
-go_minimum_version='1.19'
+go_minimum_version='1.21'
 
 #temple url
 temple_url="https://github.com/bridgewwater/temp-golang-cli-fast.git"


### PR DESCRIPTION
feat #27

- Update Go version from 1.19 to 1.21 in various workflow files and Docker images
- Update Go module version to go1.21.13
- Update golangci-lint version to v1.53.3
- Update other dependencies in go.mod file- Update Makefile and README.md with new version numbers
- Update temp-golang-cli-fast script with new version information