### PR TITLE
29 feature support build info at golang install mod sum

### DIFF
--- a/.versionrc
+++ b/.versionrc
@@ -12,5 +12,6 @@
     {"type": "chore", "section":"📦 Chores", "hidden": true},
     {"type": "revert", "section":"⏪ Reverts", "hidden": false}
   ],
-  "tag-prefix": "v"
+  "tag-prefix": "v",
+  "monorepo-pkg-path": []
 }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ### cli tools to init project fast
 
 ```bash
-$ v=1.7.0; curl -L --fail https://raw.githubusercontent.com/bridgewwater/temp-golang-cli-fast/v$v/temp-golang-cli-fast -o temp-golang-cli-fast
+$ v=1.8.0; curl -L --fail https://raw.githubusercontent.com/bridgewwater/temp-golang-cli-fast/v$v/temp-golang-cli-fast -o temp-golang-cli-fast
 # let temp-golang-cli-fast file folder under $PATH
 $ chmod +x temp-golang-cli-fast
 # see how to use

--- a/cmd/cli/app.go
+++ b/cmd/cli/app.go
@@ -8,29 +8,25 @@ import (
 	"github.com/bridgewwater/temp-golang-cli-fast/internal/urfave_cli"
 	"github.com/bridgewwater/temp-golang-cli-fast/internal/urfave_cli/cli_exit_urfave"
 	"github.com/urfave/cli/v2"
-	"runtime"
-	"time"
 )
 
 const (
-	copyrightStartYear = "2023"
-	defaultExitCode    = 1
+	// defaultExitCode SIGINT as 2
+	defaultExitCode = 2
 )
 
-func NewCliApp(buildId string) *cli.App {
+func NewCliApp(bdInfo pkg_kit.BuildInfo) *cli.App {
 	cli_exit_urfave.ChangeDefaultExitCode(defaultExitCode)
 	app := cli.NewApp()
 	app.EnableBashCompletion = true
-	app.Version = pkg_kit.GetPackageJsonVersionGoStyle(false)
-	app.Name = pkg_kit.GetPackageJsonName()
+	app.Name = bdInfo.PgkNameString()
+	app.Version = bdInfo.VersionString()
 	if pkg_kit.GetPackageJsonHomepage() != "" {
 		app.Usage = fmt.Sprintf("see: %s", pkg_kit.GetPackageJsonHomepage())
 	}
 	app.Description = pkg_kit.GetPackageJsonDescription()
-	year := time.Now().Year()
 	jsonAuthor := pkg_kit.GetPackageJsonAuthor()
-	app.Copyright = fmt.Sprintf("© %s-%d %s by: %s, build id: %s, run on %s %s",
-		copyrightStartYear, year, jsonAuthor.Name, runtime.Version(), buildId, runtime.GOOS, runtime.GOARCH)
+	app.Copyright = bdInfo.String()
 	author := &cli.Author{
 		Name:  jsonAuthor.Name,
 		Email: jsonAuthor.Email,

--- a/cmd/temp-golang-cli-fast/main.go
+++ b/cmd/temp-golang-cli-fast/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/bridgewwater/temp-golang-cli-fast"
 	"github.com/bridgewwater/temp-golang-cli-fast/cmd/cli"
+	"github.com/bridgewwater/temp-golang-cli-fast/constant"
 	"github.com/bridgewwater/temp-golang-cli-fast/internal/d_log"
 	"github.com/bridgewwater/temp-golang-cli-fast/internal/pkg_kit"
 	"github.com/gookit/color"
@@ -13,10 +14,19 @@ import (
 )
 
 const (
+	// exitCodeCmdArgs SIGINT as 2
 	exitCodeCmdArgs = 2
 )
 
-var buildID string
+//nolint:gochecknoglobals
+var (
+	// Populated by goreleaser during build
+	version    = "unknown"
+	rawVersion = "unknown"
+	buildID    string
+	commit     = "?"
+	date       = ""
+)
 
 func init() {
 	if buildID == "" {
@@ -28,7 +38,18 @@ func main() {
 	d_log.SetLogLineDeep(d_log.DefaultExtLogLineMaxDeep)
 	pkg_kit.InitPkgJsonContent(temp_golang_cli_fast.PackageJson)
 
-	app := cli.NewCliApp(buildID)
+	bdInfo := pkg_kit.NewBuildInfo(
+		pkg_kit.GetPackageJsonName(),
+		version,
+		rawVersion,
+		buildID,
+		commit,
+		date,
+		pkg_kit.GetPackageJsonAuthor().Name,
+		constant.CopyrightStartYear,
+	)
+
+	app := cli.NewCliApp(bdInfo)
 
 	args := os.Args
 	if len(args) < 2 {
@@ -37,5 +58,6 @@ func main() {
 	}
 	if err := app.Run(args); nil != err {
 		color.Redf("cli err at %v\n", err)
+		os.Exit(exitCodeCmdArgs)
 	}
 }

--- a/constant/version.go
+++ b/constant/version.go
@@ -1,0 +1,5 @@
+package constant
+
+const (
+	CopyrightStartYear = "2024"
+)

--- a/internal/pkg_kit/package_json.go
+++ b/internal/pkg_kit/package_json.go
@@ -61,6 +61,7 @@ func GetPackageJsonAuthor() Author {
 }
 
 func GetPackageJsonHomepage() string {
+	checkPackageJsonLoad()
 	return pkgJson.Homepage
 }
 
@@ -96,7 +97,7 @@ func initJsonContent() {
 	if pkgJ.Author.Name == "" {
 		panic(fmt.Errorf("pkg_kit parse package.json author name is empty"))
 	}
-	//if pkgJ.Author.Email == "" {
+	//if pkgJ.AuthorName.Email == "" {
 	//	panic(fmt.Errorf("pkg_kit parse package.json author email is empty"))
 	//}
 	pkgJson = &pkgJ

--- a/internal/pkg_kit/version.go
+++ b/internal/pkg_kit/version.go
@@ -1,0 +1,208 @@
+package pkg_kit
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"strconv"
+	"time"
+)
+
+var (
+	nowVersion = versionDevel
+	nowBuildId = infoUnknown
+)
+
+func FetchNowVersion() string {
+	return nowVersion
+}
+func FetchNowBuildId() string {
+	return nowBuildId
+}
+
+const (
+	infoUnknown  = "unknown"
+	versionDevel = "devel"
+)
+
+type BuildInfo struct {
+	PkgName string `json:"pkgName"`
+
+	Version    string `json:"version"`
+	RawVersion string `json:"rawVersion"`
+	BuildId    string `json:"buildId"`
+
+	GoVersion    string `json:"goVersion"`
+	GitCommit    string `json:"gitCommit"`
+	GitTreeState string `json:"gitTreeState"`
+	Date         string `json:"date"`
+	Compiler     string `json:"compiler"`
+	Platform     string `json:"platform"`
+
+	AuthorName         string `json:"authorName"`
+	CopyrightStartYear string `json:"copyrightStartYear"`
+	CopyrightNowYear   string `json:"copyrightNowYear"`
+}
+
+func (b BuildInfo) String() string {
+	return fmt.Sprintf("%s has version %s, © %s-%s %s,  built with %s id: %s from %s on %s, run on %s",
+		b.PkgName, b.Version, b.CopyrightStartYear, b.CopyrightNowYear, b.AuthorName, b.GoVersion, b.BuildId, b.GitCommit, b.Date, b.Platform)
+}
+
+func (b BuildInfo) Copyright() string {
+	return fmt.Sprintf("© %s-%s by: %s  build with %s id: %s, run on %s",
+		b.CopyrightStartYear, b.CopyrightNowYear, b.AuthorName, b.GoVersion, b.BuildId, b.Platform)
+}
+
+func (b BuildInfo) PgkNameString() string {
+	return b.PkgName
+}
+
+func (b BuildInfo) VersionString() string {
+	return b.Version
+}
+
+func (b BuildInfo) RawVersionString() string {
+	return b.RawVersion
+}
+
+func NewBuildInfo(
+	pkgName, version, rawVersion,
+	buildId, commit, date,
+	author, copyrightStartYear string,
+) BuildInfo {
+	info := BuildInfo{
+		PkgName: pkgName,
+
+		Version:    version,
+		RawVersion: rawVersion,
+		BuildId:    buildId,
+		GitCommit:  commit,
+		Date:       date,
+		Compiler:   runtime.Compiler,
+		Platform:   fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+
+		AuthorName:         author,
+		CopyrightStartYear: copyrightStartYear,
+		CopyrightNowYear:   strconv.Itoa(time.Now().Year()),
+	}
+
+	bi, available := debug.ReadBuildInfo()
+	if !available {
+		return info
+	}
+
+	info.GoVersion = bi.GoVersion
+	if info.GoVersion == "" {
+		info.GoVersion = infoUnknown
+	}
+
+	if info.Version == "" || info.Version == infoUnknown {
+		info.Version = firstNonEmpty(getGitVersion(bi), versionDevel)
+	}
+
+	nowVersion = info.Version
+	nowBuildId = info.BuildId
+
+	if date != "" {
+		return info
+	}
+
+	var revision string
+	var modified string
+	for _, setting := range bi.Settings {
+		// The `vcs.xxx` information is only available with `go build`.
+		// This information is not available with `go install` or `go run`.
+		switch setting.Key {
+		case "vcs.time":
+			info.Date = setting.Value
+		case "vcs.revision":
+			revision = setting.Value
+		case "vcs.modified":
+			modified = setting.Value
+		}
+	}
+
+	if revision == "" {
+		revision = infoUnknown
+	}
+
+	if modified == "" {
+		modified = "?"
+	}
+
+	if info.Date == "" {
+		info.Date = fmt.Sprintf("(%s)", infoUnknown)
+	}
+
+	if info.BuildId == "" {
+		info.BuildId = fmt.Sprintf("(%s)", infoUnknown)
+	}
+
+	info.GitCommit = fmt.Sprintf("(%s, modified: %s, mod sum: %q)", revision, modified, bi.Main.Sum)
+
+	return info
+}
+
+func getGitVersion(bi *debug.BuildInfo) string {
+	if bi == nil {
+		return ""
+	}
+
+	// remove this when the issue https://github.com/golang/go/issues/29228 is fixed
+	if bi.Main.Version == "(devel)" || bi.Main.Version == "" {
+		return ""
+	}
+
+	return bi.Main.Version
+}
+
+//nolint:golint,unused
+func getCommit(bi *debug.BuildInfo) string {
+	return getKey(bi, "vcs.revision")
+}
+
+//nolint:golint,unused
+func getDirty(bi *debug.BuildInfo) string {
+	modified := getKey(bi, "vcs.modified")
+	if modified == "true" {
+		return "dirty"
+	}
+	if modified == "false" {
+		return "clean"
+	}
+	return ""
+}
+
+//nolint:golint,unused
+func getBuildDate(bi *debug.BuildInfo) string {
+	buildTime := getKey(bi, "vcs.time")
+	t, err := time.Parse("2006-01-02T15:04:05Z", buildTime)
+	if err != nil {
+		return ""
+	}
+	return t.Format("2006-01-02T15:04:05")
+}
+
+//nolint:golint,unused
+func getKey(bi *debug.BuildInfo, key string) string {
+	if bi == nil {
+		return ""
+	}
+	for _, iter := range bi.Settings {
+		if iter.Key == key {
+			return iter.Value
+		}
+	}
+	return ""
+}
+
+//nolint:golint,unused
+func firstNonEmpty(ss ...string) string {
+	for _, s := range ss {
+		if s != "" {
+			return s
+		}
+	}
+	return ""
+}

--- a/internal/pkg_kit/version_test.go
+++ b/internal/pkg_kit/version_test.go
@@ -1,0 +1,140 @@
+package pkg_kit
+
+import (
+	"runtime/debug"
+	"testing"
+	"time"
+)
+
+func TestGetGitVersion(t *testing.T) {
+	t.Run("null buildinfo", func(t *testing.T) {
+		if got := getGitVersion(nil); got != "" {
+			t.Fatalf("expected empty string, got %q", got)
+		}
+	})
+	t.Run("devel", func(t *testing.T) {
+		if got := getGitVersion(&debug.BuildInfo{
+			Main: debug.Module{
+				Version: "(devel)",
+			},
+		}); got != "" {
+			t.Fatalf("expected empty string, got %q", got)
+		}
+	})
+	t.Run("empty", func(t *testing.T) {
+		if got := getGitVersion(&debug.BuildInfo{}); got != "" {
+			t.Fatalf("expected empty string, got %q", got)
+		}
+	})
+	t.Run("versioned", func(t *testing.T) {
+		v := "1.0.0"
+		if got := getGitVersion(&debug.BuildInfo{
+			Main: debug.Module{
+				Version: v,
+			},
+		}); got != v {
+			t.Fatalf("expected %q, got %q", v, got)
+		}
+	})
+}
+
+func TestGetDirty(t *testing.T) {
+	t.Run(infoUnknown, func(t *testing.T) {
+		if got := getDirty(&debug.BuildInfo{}); got != "" {
+			t.Fatalf("expected empty string, got %q", got)
+		}
+	})
+	t.Run("dirty", func(t *testing.T) {
+		if got := getDirty(&debug.BuildInfo{
+			Settings: []debug.BuildSetting{
+				{
+					Key:   "vcs.modified",
+					Value: "true",
+				},
+			},
+		}); got != "dirty" {
+			t.Fatalf("expected dirty, got %q", got)
+		}
+	})
+	t.Run("clean", func(t *testing.T) {
+		if got := getDirty(&debug.BuildInfo{
+			Settings: []debug.BuildSetting{
+				{
+					Key:   "vcs.modified",
+					Value: "false",
+				},
+			},
+		}); got != "clean" {
+			t.Fatalf("expected clean, got %q", got)
+		}
+	})
+}
+
+func TestGetBuildDate(t *testing.T) {
+	t.Run(infoUnknown, func(t *testing.T) {
+		if got := getBuildDate(&debug.BuildInfo{}); got != "" {
+			t.Fatalf("expected empty string, got %q", got)
+		}
+	})
+	t.Run("invalid", func(t *testing.T) {
+		if got := getBuildDate(&debug.BuildInfo{
+			Settings: []debug.BuildSetting{
+				{
+					Key:   "vcs.time",
+					Value: "not a date",
+				},
+			},
+		}); got != "" {
+			t.Fatalf("expected an empty string, got %q", got)
+		}
+	})
+	t.Run("time", func(t *testing.T) {
+		now := time.Now()
+		if got := getBuildDate(&debug.BuildInfo{
+			Settings: []debug.BuildSetting{
+				{
+					Key:   "vcs.time",
+					Value: now.Format("2006-01-02T15:04:05Z"),
+				},
+			},
+		}); got != now.Format("2006-01-02T15:04:05") {
+			t.Fatalf("expected %q, got %q", now, got)
+		}
+	})
+}
+
+func TestGetKey(t *testing.T) {
+	t.Run("nil buildinfo", func(t *testing.T) {
+		if got := getKey(nil, "any"); got != "" {
+			t.Fatalf("expected an empty string, got %q", got)
+		}
+	})
+	t.Run("valid", func(t *testing.T) {
+		key := "key"
+		expect := "value"
+		if got := getKey(&debug.BuildInfo{
+			Settings: []debug.BuildSetting{
+				{
+					Key:   key,
+					Value: expect,
+				},
+			},
+		}, key); got != expect {
+			t.Fatalf("expected %q, got %q", expect, got)
+		}
+	})
+}
+
+func TestFirstNonEmpty(t *testing.T) {
+	t.Run("normal", func(t *testing.T) {
+		expect := "aaa"
+		if got := firstNonEmpty("", "", expect, ""); got != expect {
+			t.Fatalf("expected %q, got %q", expect, got)
+		}
+	})
+	t.Run("all empty", func(t *testing.T) {
+		if got := firstNonEmpty("", "", ""); got != "" {
+			t.Fatalf("expected an empty string, got %q", got)
+		}
+	})
+}

--- a/internal/urfave_cli/cli_exit_urfave/exit.go
+++ b/internal/urfave_cli/cli_exit_urfave/exit.go
@@ -5,7 +5,8 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-const exitCodeDefault = 127
+// exitCodeDefault SIGUSR1 as 10
+const exitCodeDefault = 10
 
 var exitCode = exitCodeDefault
 

--- a/temp-golang-cli-fast
+++ b/temp-golang-cli-fast
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # and this use tag
-temple_version='1.7.0'
+temple_version='1.8.0'
 new_version_for_dev='1.0.0'
 go_minimum_version='1.21'
 


### PR DESCRIPTION
feat #29

- Add BuildInfo struct to consolidate build-related information
- Update version handling to use BuildInfo- Modify copyright year to 2024
- Refactor version-related functions in pkg_kit package
- Update tests for version-related functions