### PR TITLE
build(ci): adjust workflows for release process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths-ignore:
       - '**/README.md'
+      - '**/doc-dev/*'
     branches:
       # - 'main'
       - 'release-*'
@@ -49,7 +50,7 @@ jobs:
     with:
       run_test_case: true
       run_golangci_lint: true
-      run_benchmark: false
+      run_benchmark: ${{ ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) || github.base_ref == 'main' }}
       run_test_coverage: true
 
   go-build-check-main:
@@ -75,7 +76,7 @@ jobs:
     with:
       version_name: ${{ needs.version.outputs.tag_name }}
       go_build_id: ${{ needs.version.outputs.short_sha }}
-      upload_artifact_name: go-release
+      # upload_artifact_name: go-release
 
   deploy-tag:
     needs:
@@ -90,4 +91,4 @@ jobs:
       prerelease: true
       tag_name: ${{ needs.version.outputs.tag_name }}
       tag_changes: ${{ needs.version.outputs.cc_changes }}
-      download_artifact_name: go-release # download artifact name, download from actions/upload-artifact, as: {download_artifact_name}-{tag_name}-*, empty is not download
+      # download_artifact_name: go-release # download artifact name, download from actions/upload-artifact, as: {download_artifact_name}-{tag_name}-*, empty is not download

--- a/.github/workflows/deploy-tag.yml
+++ b/.github/workflows/deploy-tag.yml
@@ -38,6 +38,13 @@ jobs:
     name: repo-release
     runs-on: ubuntu-latest
     steps:
+      - name: Check inputs
+        run: |
+          echo "inputs.dry_run: ${{ inputs.dry_run }}"
+          echo "inputs.prerelease: ${{ inputs.prerelease }}"
+          echo "inputs.tag_name: ${{ inputs.tag_name }}"
+          echo "inputs.download_artifact_name: ${{ inputs.download_artifact_name }}"
+
       - uses: actions/checkout@v4
 
       - name: Check deploy inputs
@@ -72,7 +79,7 @@ jobs:
           # body_path: ${{ github.workspace }}/CHANGELOG.md
           ## set release binaries, empty means do not upload files for release
           # https://github.com/isaacs/node-glob
-          files: |
-            **/*.zip
-            **/*.tar.gz
-            **/*.sha256
+          # files: |
+          #   **/*.zip
+          #   **/*.tar.gz
+          #   **/*.sha256

--- a/.github/workflows/go-release-platform.yml
+++ b/.github/workflows/go-release-platform.yml
@@ -62,6 +62,14 @@ jobs:
             go_arch: arm64
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Check inputs
+        run: |
+          echo "github.run_id: ${{ github.run_id }}"
+          echo "github.run_attempt: ${{ github.run_attempt }}"
+          echo "inputs.version_name: ${{ inputs.version_name }}"
+          echo "inputs.upload_artifact_name: ${{ inputs.upload_artifact_name }}"
+          echo "inputs.go_build_id: ${{ inputs.go_build_id }}"
+
       - uses: actions/checkout@v4
       - name: Set up Go SDK
         uses: actions/setup-go@v5

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -57,6 +57,8 @@ jobs:
 
       - name: check version and conventional
         run: |
+          echo "github.run_id: ${{ github.run_id }}"
+          echo "github.run_attempt: ${{ github.run_attempt }}"
           echo "sha: ${{ steps.check-version.outputs.sha }}"
           echo "env SHA-SHORT: ${{ env.SHA-SHORT }}"
           echo "short-sha: ${{ steps.check-version.outputs.short-sha }}"


### PR DESCRIPTION
- Modify ci.yml to run benchmarks only on main branch or when comparing to main
- Update deploy-tag.yml to include input checking and disable artifact download
- Adjust go-release-platform.yml to add input checking
- Update version.yml to add run ID and attempt information
- Ignore changes in doc-dev directory for CI triggers
