### PR TITLE
fix: update error message for invalid semantic version

### DIFF
--- a/internal/cli_kit/version_check/version_check_test.go
+++ b/internal/cli_kit/version_check/version_check_test.go
@@ -39,7 +39,7 @@ func TestSemverVersionMinimumSupport(t *testing.T) {
 				version:     "Semantic Versioning",
 				lessVersion: "1.0.0",
 			},
-			wantErr: fmt.Errorf("can not parse target version: Semantic Versioning err: Invalid Semantic Version"),
+			wantErr: fmt.Errorf("can not parse target version: Semantic Versioning err: invalid semantic version"),
 		},
 		{
 			name: "not support less version",
@@ -133,7 +133,7 @@ func TestSemverVersionConstraint(t *testing.T) {
 				minimumVersion: "1.0.0",
 				maximumVersion: "2.0.0",
 			},
-			wantErr: fmt.Errorf("can not parse target version: Semantic Versioning err: Invalid Semantic Version"),
+			wantErr: fmt.Errorf("can not parse target version: Semantic Versioning err: invalid semantic version"),
 		},
 		{
 			name: "not support minimumVersion",


### PR DESCRIPTION
Change error message from "Invalid Semantic Version" to "invalid semantic version" to match expected format in test cases.